### PR TITLE
Add standard logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ replace pkg/stream => ./pkg/stream
 
 replace internal/colorizer => ./internal/colorizer
 
+replace pkg/templates/log => ./pkg/templates/log
+
 replace pkg/config => ./pkg/config
 
 replace pkg/utils => ./pkg/utils
@@ -124,5 +126,6 @@ require (
 	pkg/certstream v0.0.0-00010101000000-000000000000 // indirect
 	pkg/config v0.0.0-00010101000000-000000000000 // indirect
 	pkg/http v0.0.0-00010101000000-000000000000 // indirect
+	pkg/templates/log v0.0.0-00010101000000-000000000000 // indirect
 	pkg/yamlreader v0.0.0-00010101000000-000000000000 // indirect
 )

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -66,7 +66,7 @@ func ParseOptions() *Options {
 	}
 
 	// Loaded Configuration File
-	// This is default configuration
+	// This comment indicates that the configuration file has been loaded
 	c, err := config.LoadConfig()
 
 	if err != nil {
@@ -74,15 +74,20 @@ func ParseOptions() *Options {
 	}
 
 	// Default Configuration Output
+	// This line sets the log level to the default configuration
 	options.SetLogLevel(&c)
 
-	// If the user desires verbose output, show verbose output
+	// Load configuration information
+	config, _ := config.Load()
+
+	// If the user has requested verbose output, show it
 	if options.Version {
 		log.Info().Msgf("Certwatcher version %s\n", config.Version)
 		os.Exit(0)
 	}
 
 	// Show the certwatcher banner
+	// This line displays the Certwatcher banner on the consolegot
 	ShowBanner()
 
 	return options

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,25 +1,17 @@
 package config
 
 import (
-    "encoding/json"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/mitchellh/go-homedir"
-	"github.com/spf13/viper"
 	"io/ioutil"
-	"gopkg.in/yaml.v3"
-	log "github.com/projectdiscovery/gologger"
-)
 
-var (
-	// Version represents the current version of the application
-	Version = "0.1.2"
-	// Name represents the name of the application
-	Name = "certwatcher"
-	// The `Notice` variable represents a notice about the current state of the application.
-	Notice = "\n\nThis project is in active development not ready for production. \nPlease use a proxy to stay safe. Use at your own risk."
+	"github.com/mitchellh/go-homedir"
+	log "github.com/projectdiscovery/gologger"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 type OpenAIConfig struct {
@@ -66,9 +58,9 @@ type AppConfig struct {
 
 // Config is the configuration struct
 type Config struct {
-	Log       LogConfig    `mapstructure:"log"`
-	Stream    StreamConfig `mapstructure:"stream"`
-	OpenAI    OpenAIConfig `mapstructure:"openai"`
+	Log    LogConfig    `mapstructure:"log"`
+	Stream StreamConfig `mapstructure:"stream"`
+	OpenAI OpenAIConfig `mapstructure:"openai"`
 }
 
 // Load Configuration JSON
@@ -146,7 +138,7 @@ func createDefaultConfig() error {
 				Mode: "live",
 			},
 			Domains: []string{},
-			Ignore: false,
+			Ignore:  false,
 		},
 	}
 	// Convert the default config to YAML format

--- a/pkg/core/templates.go
+++ b/pkg/core/templates.go
@@ -6,8 +6,9 @@ import (
     "pkg/catalog/disk"
     "pkg/types"
     "pkg/utils"
-    yaml "pkg/yamlreader"
     "strings"
+
+    yaml "pkg/yamlreader"
 
     "github.com/logrusorgru/aurora/v4"
     log "github.com/projectdiscovery/gologger"
@@ -69,13 +70,6 @@ func Summary(template types.Templates, matchers []string, loadsTemplates []strin
 }
 
 func Templates(options types.Options) []Models {
-    // Encontrar os templates a serem usados
-    catalog := &disk.DiskCatalog{}
-    templates, err := catalog.Find(options.Templates)
-
-    if err != nil {
-        log.Fatal().Msgf("%s", err)
-    }
 
     // Slice para armazenar as informações de cada template
     var Templates []Models
@@ -88,6 +82,14 @@ func Templates(options types.Options) []Models {
     tagsMap := make(map[string]map[string]bool)
     // Initialize a map to keep track of processed templates
     processed := make(map[string]bool)
+
+    // Encontrar os templates a serem usados
+    catalog := &disk.DiskCatalog{}
+    templates, err := catalog.Find(options.Templates)
+
+    if err != nil {
+        log.Fatal().Msgf("%s", err)
+    }
 
     var template types.Templates
 

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -12,14 +12,6 @@ import (
 	"pkg/matchers"
 )
 
-type Message struct {
-	Domain         string
-	Domains        []string
-	Issuer         string
-	Source         string
-	SubjectAltName string
-}
-
 // Certificates captures certificates from a CertStream, a real-time feed of newly issued SSL/TLS certificates.
 // It takes a slice of keywords to check against the domain name of each certificate received and a list of valid TLDs.
 func Certificates(t []core.Models) {

--- a/pkg/templates/log/go.mod
+++ b/pkg/templates/log/go.mod
@@ -1,0 +1,3 @@
+module pkg/templates/log
+
+go 1.20

--- a/pkg/templates/log/logger.go
+++ b/pkg/templates/log/logger.go
@@ -1,0 +1,54 @@
+package templates
+
+import (
+    "fmt"
+    "os"
+    "time"
+)
+
+type CertLogger struct {
+    logFile *os.File
+}
+
+// Initializes a new CertLogger object
+func New(logFilePath string) (*CertLogger, error) {
+    // Check if the log file exists. If not, create it.
+    _, err := os.Stat(logFilePath)
+    if os.IsNotExist(err) {
+        f, err := os.Create(logFilePath)
+        if err != nil {
+            return nil, fmt.Errorf("error creating log file: %s", err)
+        }
+        f.Close()
+    }
+
+    // Open the log file for appending
+    logFile, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_WRONLY, 0644)
+    if err != nil {
+        return nil, fmt.Errorf("error opening log file: %s", err)
+    }
+
+    // Create the CertLogger object
+    logger := &CertLogger{logFile: logFile}
+
+    return logger, nil
+}
+
+// Writes a log message to the log file
+func (logger *CertLogger) WriteLog(message string) error {
+    // Create a timestamp for the log entry
+    timestamp := time.Now().Format("2006-01-02 15:04:05")
+
+    // Write the log message to the file
+    _, err := logger.logFile.WriteString(fmt.Sprintf("[%s] %s\n", timestamp, message))
+    if err != nil {
+        return fmt.Errorf("error writing to log file: %s", err)
+    }
+
+    return nil
+}
+
+// Closes the log file
+func (logger *CertLogger) Close() error {
+    return logger.logFile.Close()
+}

--- a/pkg/yamlreader/yamlreader.go
+++ b/pkg/yamlreader/yamlreader.go
@@ -2,11 +2,12 @@ package yamlreader
 
 import (
 	"io/ioutil"
+
 	log "github.com/projectdiscovery/gologger"
 	"gopkg.in/yaml.v3"
 )
 
-// ReadYAML lê uma string YAML ou um arquivo YAML e retorna um struct preenchido com os dados
+// ReadYAML
 func ReadYAML(src interface{}, v interface{}) error {
 	var data []byte
 	var err error


### PR DESCRIPTION
### Changes

1. The centralized log location for Certwatcher will be in the directory /var/log/certwatcher.log.